### PR TITLE
Improve the flash algorithm

### DIFF
--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -137,7 +137,7 @@ void CheckIfFlashed(float[3] pos)
     float flashAvoidance_X = (angle[1] * basePercentile);
 
     //PrintToServer("Angles %f %f", angle[0], angle[1]);
-    if (angle[0] >= 45 || angle[1] >= 45)
+    if (angle[0] >= 75 || angle[1] >= 75)
     {
       //PrintToServer("Reducing from %f", flashedPercent);
       flashedPercent -= flashAvoidance_Y;

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -125,7 +125,7 @@ void CheckIfFlashed(float[3] pos)
     // Start at this percentage flashed
     float flashedPercent = 100.0;
 
-    PrintToChat(i, "Flashed! Initial flash: %i percent", RoundToNearest(flashedPercent));
+    //PrintToChat(i, "Flashed! Initial flash: %i percent", RoundToNearest(flashedPercent));
 
     // flashed percentile unit (~100/180 = 0.555)
     float basePercentile = 0.555;
@@ -136,17 +136,17 @@ void CheckIfFlashed(float[3] pos)
     float flashAvoidance_Y = (angle[0] * basePercentile);
     float flashAvoidance_X = (angle[1] * basePercentile);
 
-    PrintToServer("Angles %f %f", angle[0], angle[1]);
+    //PrintToServer("Angles %f %f", angle[0], angle[1]);
     if (angle[0] >= 45 || angle[1] >= 45)
     {
-      PrintToServer("Reducing from %f", flashedPercent);
+      //PrintToServer("Reducing from %f", flashedPercent);
       flashedPercent -= flashAvoidance_Y;
       flashedPercent -= flashAvoidance_X;
-      PrintToServer("to %f", flashedPercent);
+      //PrintToServer("to %f", flashedPercent);
     }
     else
     {
-      PrintToServer("False, %f >= 90 || %f >= 90", angle[0], angle[1]);
+      //PrintToServer("False, %f >= 90 || %f >= 90", angle[0], angle[1]);
     }
 
     // Cap final flash amount
@@ -157,15 +157,14 @@ void CheckIfFlashed(float[3] pos)
 
     int intensity = RoundToNearest(flashedPercent);
     int duration = RoundToNearest(intensity * 10 - distance*0.5);
-    PrintToServer("duration %i = %i * 10 - %f", duration, intensity, distance/10);
+    //PrintToServer("duration %i = %i * 10 - %f", duration, intensity, distance/10);
 
     if (duration > 1000)
       duration = 1000;
     else if (duration < 50)
       duration = 50;
 
-    PrintToChat(i, "Amount after dodge: %i percent", intensity);
-    PrintToChat(i, "Flashed duration: %i", duration);
+    PrintToChat(i, "Flashed! Intensity %i%%, duration %i%%)", intensity, duration/10);
     BlindPlayer(i, intensity, duration);
 
     /*

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -230,11 +230,11 @@ bool TraceHitEyes(int client, float[3] startPos, float[3] eyePos)
 public bool TraceFilter_IsPlayer(int hitEntity, int mask, any targetClient)
 {
   if (hitEntity == targetClient) {
-    PrintToServer("hitEntity %i target %i = %b", hitEntity, targetClient, true);
+    //PrintToServer("hitEntity %i target %i = %b", hitEntity, targetClient, true);
     return true;
   }
 
-  PrintToServer("hitEntity %i target %i = %b", hitEntity, targetClient, false);
+  //PrintToServer("hitEntity %i target %i = %b", hitEntity, targetClient, false);
   return false;
 }
 

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -2,7 +2,7 @@
 #include <sdktools>
 #include <neotokyo>
 
-#define PLUGIN_VERSION "0.1"
+#define PLUGIN_VERSION "0.1_cvars"
 
 new const String:g_sFlashSound_Environment[] = "player/cx_fire.wav";
 new const String:g_sFlashSound_Victim[] = "weapons/hegrenade/frag_explode.wav";

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -7,6 +7,8 @@
 new const String:g_sFlashSound_Environment[] = "player/cx_fire.wav";
 new const String:g_sFlashSound_Victim[] = "weapons/hegrenade/frag_explode.wav";
 
+Handle g_hCvar_Enabled;
+
 Handle g_hCvar_Debug_FuseLength;
 Handle g_hCvar_Debug_FlashPercent;
 Handle g_hCvar_Debug_FlashPercentDivisor;
@@ -31,6 +33,8 @@ public Plugin myinfo = {
 
 public void OnPluginStart()
 {
+  g_hCvar_Enabled = CreateConVar("sm_flashbang_enabled", "1.0", "Toggle NT flashbang plugin on/off", _, true, 0.0, true, 1.0);
+
   CreateConVar("sm_flashbang_version", PLUGIN_VERSION, "NT Flashbang plugin version.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED);
 
   g_hCvar_Debug_FuseLength = CreateConVar("sm_flashbang_debug_fuse", "1.5", "Flashbang fuse length. Debug command.", _, true, 0.1);
@@ -62,6 +66,10 @@ public void OnMapStart()
 // Purpose: Create a new timer on each thrown HE grenade to turn them into flashes
 public void OnEntityCreated(int entity, const char[] classname)
 {
+  if (!GetConVarBool(g_hCvar_Enabled)) {
+    return;
+  }
+
   if (StrEqual(classname, "grenade_projectile")) {
     CreateTimer(GetConVarFloat(g_hCvar_Debug_FuseLength), Timer_Flashify, entity);
   }

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -2,7 +2,7 @@
 #include <sdktools>
 #include <neotokyo>
 
-#define PLUGIN_VERSION "0.1_cvars"
+#define PLUGIN_VERSION "0.2"
 
 #define FLASHBANG_FUSE 1.5
 

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -4,21 +4,12 @@
 
 #define PLUGIN_VERSION "0.1_cvars"
 
+#define FLASHBANG_FUSE 1.5
+
 new const String:g_sFlashSound_Environment[] = "player/cx_fire.wav";
 new const String:g_sFlashSound_Victim[] = "weapons/hegrenade/frag_explode.wav";
 
 Handle g_hCvar_Enabled;
-
-Handle g_hCvar_Debug_FuseLength;
-Handle g_hCvar_Debug_FlashPercent;
-Handle g_hCvar_Debug_FlashPercentDivisor;
-Handle g_hCvar_Debug_MinimumInitialFlash;
-Handle g_hCvar_Debug_BasePercentile;
-Handle g_hCvar_Debug_BestDodge;
-Handle g_hCvar_Debug_ViewAlpha_Multiplier;
-Handle g_hCvar_Debug_ViewAlpha_Min;
-Handle g_hCvar_Debug_Volume_Multiplier;
-Handle g_hCvar_Debug_Volume_Min;
 
 public Plugin myinfo = {
   name = "NT Flashbangs",
@@ -33,20 +24,6 @@ public void OnPluginStart()
   g_hCvar_Enabled = CreateConVar("sm_flashbang_enabled", "1.0", "Toggle NT flashbang plugin on/off", _, true, 0.0, true, 1.0);
 
   CreateConVar("sm_flashbang_version", PLUGIN_VERSION, "NT Flashbang plugin version.", FCVAR_PLUGIN|FCVAR_SPONLY|FCVAR_REPLICATED);
-
-  g_hCvar_Debug_FuseLength = CreateConVar("sm_flashbang_debug_fuse", "1.5", "Flashbang fuse length. Debug command.", _, true, 0.1);
-  g_hCvar_Debug_FlashPercent = CreateConVar("sm_flashbang_debug_CheckIfFlashed_initial_flashed_percent", "100", "CheckIfFlashed - float flashedPercent (Start at this percentage flashed)", _, true, 0.0);
-  g_hCvar_Debug_FlashPercentDivisor = CreateConVar("sm_flashbang_debug_CheckIfFlashed_initial_flashed_percent_divisor", "85", "CheckIfFlashed - float distance (Reduce flashedness based on distance)", _, true, 1.0);
-  g_hCvar_Debug_MinimumInitialFlash = CreateConVar("sm_flashbang_debug_CheckIfFlashed_minimum_initial_flash", "100", "CheckIfFlashed - float minimumInitialFlash (Cap flash reduction)", _, true, 0.0, true, 100.0);
-
-  g_hCvar_Debug_BasePercentile = CreateConVar("sm_flashbang_debug_base_percentile", "0.555", "CheckIfFlashed - float basePercentile (flashed percentile unit, ~100/180)");
-  g_hCvar_Debug_BestDodge = CreateConVar("sm_flashbang_debug_best_dodge", "25", "CheckIfFlashed - float bestPossibleDodge (can negate max 100%-bestPossibleDodge of flash by turning)");
-
-  g_hCvar_Debug_ViewAlpha_Multiplier = CreateConVar("sm_flashbang_debug_view_alpha_multiplier", "2.5", "BlindPlayer - float (multiplier * internsity = view alpha)");
-  g_hCvar_Debug_ViewAlpha_Min = CreateConVar("sm_flashbang_debug_view_alpha_minimum", "5", "BlindPlayer - int (minimum view alpha)", _, true, 0.0);
-
-  g_hCvar_Debug_Volume_Multiplier = CreateConVar("sm_flashbang_debug_volume_multipliler", "0.007", "BlindPlayer - float (multiplier * intensity = blind victim fx volume)", _, true, 0.0);
-  g_hCvar_Debug_Volume_Min = CreateConVar("sm_flashbang_debug_volume_minimum", "0.1", "BlindPlayer - float (minimum blind victim fx volume, range 0.0-1.0)", _, true, 0.0, true, 1.0);
 }
 
 public void OnConfigsExecuted()
@@ -68,7 +45,7 @@ public void OnEntityCreated(int entity, const char[] classname)
   }
 
   if (StrEqual(classname, "grenade_projectile")) {
-    CreateTimer(GetConVarFloat(g_hCvar_Debug_FuseLength), Timer_Flashify, entity);
+    CreateTimer(FLASHBANG_FUSE, Timer_Flashify, entity);
   }
 }
 
@@ -146,20 +123,14 @@ void CheckIfFlashed(float[3] pos)
     float distance = GetVectorDistance(eyePos, pos);
 
     // Start at this percentage flashed
-    float flashedPercent = GetConVarFloat(g_hCvar_Debug_FlashPercent);
-    // Reduce flashedness based on distance
-    flashedPercent -= distance / GetConVarFloat(g_hCvar_Debug_FlashPercentDivisor);
-    // Cap reduction
-    float minimumInitialFlash = GetConVarFloat(g_hCvar_Debug_MinimumInitialFlash);
-    if (flashedPercent < minimumInitialFlash)
-      flashedPercent = minimumInitialFlash;
+    float flashedPercent = 100.0;
 
     PrintToChat(i, "Flashed! Initial flash: %i percent", RoundToNearest(flashedPercent));
 
     // flashed percentile unit (~100/180 = 0.555)
-    float basePercentile = GetConVarFloat(g_hCvar_Debug_BasePercentile);
+    float basePercentile = 0.555;
     // can negate max 100%-bestPossibleDodge of flash by turning
-    float bestPossibleDodge = GetConVarFloat(g_hCvar_Debug_BestDodge);
+    float bestPossibleDodge = 25.0;
 
     // Reduce flashedness based on dodge on X and Y axes
     float flashAvoidance_Y = (angle[0] * basePercentile);
@@ -265,15 +236,13 @@ void BlindPlayer(int client, int intensity, int resetDuration)
     ClientCommand(client, "-thermoptic");
   }
 
-  //int resetDuration = RoundToNearest(GetConVarFloat(g_hCvar_Debug_ResetDuration_Multipier) * intensity);
+  int alpha = RoundToNearest(2.5 * intensity);
+  if (alpha < 5)
+    alpha = 5;
 
-  int alpha = RoundToNearest(GetConVarFloat(g_hCvar_Debug_ViewAlpha_Multiplier) * intensity);
-  if (alpha < GetConVarInt(g_hCvar_Debug_ViewAlpha_Min))
-    alpha = GetConVarInt(g_hCvar_Debug_ViewAlpha_Min);
-
-  float volume = GetConVarFloat(g_hCvar_Debug_Volume_Multiplier) * intensity;
-  if (volume < GetConVarFloat(g_hCvar_Debug_Volume_Min))
-    volume = GetConVarFloat(g_hCvar_Debug_Volume_Min);
+  float volume = 0.007 * intensity;
+  if (volume < 0.1)
+    volume = 0.1;
 
   Handle userMsg = StartMessageOne("Fade", client);
   BfWriteShort(userMsg, 500); // Flash duration

--- a/scripting/nt_flashbang.sp
+++ b/scripting/nt_flashbang.sp
@@ -57,6 +57,11 @@ public void OnPluginStart()
   g_hCvar_Debug_Volume_Min = CreateConVar("sm_flashbang_debug_volume_minimum", "0.1", "BlindPlayer - float (minimum blind victim fx volume, range 0.0-1.0)", _, true, 0.0, true, 1.0);
 }
 
+public void OnConfigsExecuted()
+{
+  AutoExecConfig(true);
+}
+
 public void OnMapStart()
 {
   PrecacheSound(g_sFlashSound_Environment);

--- a/scripting/nt_flashbang_vote.sp
+++ b/scripting/nt_flashbang_vote.sp
@@ -33,7 +33,7 @@ public void OnPluginStart()
 
 public Action Event_RoundStart(Handle event, const char[] name, bool dontBroadcast)
 {
-  PrintToChatAll("Turn frag grenades into flashbangs in currently: %sd", status[GetConVarBool(g_hCvar_Flashbang_Enabled)]);
+  PrintToChatAll("Turn frag grenades into flashbangs is currently: %sd", status[GetConVarBool(g_hCvar_Flashbang_Enabled)]);
   PrintToChatAll("You can toggle this with !voteflash");
 }
 

--- a/scripting/nt_flashbang_vote.sp
+++ b/scripting/nt_flashbang_vote.sp
@@ -1,0 +1,117 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <neotokyo>
+
+new const String:status[][] = {"disable", "enable"};
+
+int g_iLastVoteEpoch;
+
+Handle g_hCvar_Enabled;
+Handle g_hCvar_Flashbang_Enabled;
+
+public Plugin myinfo = {
+  name = "NT Flashbangs Vote",
+  description = "Allow players to vote for flashbangs",
+  author = "Rain",
+  version = "0.1",
+  url = "https://github.com/Rainyan/sourcemod-nt-flashbang"
+};
+
+public void OnPluginStart()
+{
+  RegConsoleCmd("sm_voteflash", Command_VoteFlash);
+
+  g_hCvar_Enabled = CreateConVar("sm_flashbang_vote_enabled", "1.0", "Toggle flashbang voting on/off", _, true, 0.0, true, 1.0);
+
+  g_hCvar_Flashbang_Enabled = FindConVar("sm_flashbang_enabled");
+  if (g_hCvar_Flashbang_Enabled == null)
+    SetFailState("NT Flashbang plugin not found.");
+}
+
+public Action Command_VoteFlash(int client, int args)
+{
+  if (!GetConVarBool(g_hCvar_Enabled))
+  {
+    ReplyToCommand(client, "Sorry, flashbang voting is currently disabled!");
+    return Plugin_Stop;
+  }
+
+  Handle cvarVoteDelay = FindConVar("sm_vote_delay");
+  int voteDelay = GetConVarInt(cvarVoteDelay);
+  delete cvarVoteDelay;
+
+  int timePassed = GetTime() - g_iLastVoteEpoch;
+  if (timePassed < voteDelay)
+  {
+    ReplyToCommand(client, "You must wait at least %i seconds before another flashbang vote",
+      voteDelay - timePassed);
+    return Plugin_Stop;
+  }
+
+  bool flashEnabled = GetConVarBool(g_hCvar_Flashbang_Enabled);
+
+  char menuTitle[20];
+  Format(menuTitle, sizeof(menuTitle), "%s flashbangs?", status[!flashEnabled]);
+
+  Menu menu = new Menu(MenuHandler_Vote);
+  menu.SetTitle(menuTitle);
+  menu.AddItem("Yes", "yes");
+  menu.AddItem("No", "no");
+
+  if (!VoteMenuToAll(menu, 10))
+  {
+    ReplyToCommand(client, "Vote is already running!");
+    return Plugin_Stop;
+  }
+
+  char clientName[MAX_NAME_LENGTH];
+  GetClientName(client, clientName, sizeof(clientName));
+
+  PrintToChatAll("[SM] %s has initiated a %s flashbangs vote",
+    clientName, status[!flashEnabled]);
+
+  return Plugin_Handled;
+}
+
+public int MenuHandler_Vote(Menu menu, MenuAction action, int param1, int param2)
+{
+  if (action == MenuAction_End)
+  {
+    delete menu;
+    return;
+  }
+  if (action != MenuAction_VoteEnd)
+  {
+    return;
+  }
+
+  g_iLastVoteEpoch = GetTime();
+
+  // "Yes" in the visual menu = 0, "no" = 1
+  bool result = !param1;
+  bool flashEnabled = GetConVarBool(g_hCvar_Flashbang_Enabled);
+
+  int winningVotes;
+  int totalVotes;
+  GetMenuVoteInfo(param2, winningVotes, totalVotes);
+
+  if (!result)
+  {
+    PrintToChatAll("[SM] Flashbangs %s vote didn't pass (%i of %i voted against)",
+      status[!flashEnabled], winningVotes, totalVotes);
+
+    return;
+  }
+
+  ToggleFlashbangs();
+
+  PrintToChatAll("[SM] Flashbangs have been %sd (%i of %i voted yes)",
+    status[!flashEnabled], winningVotes, totalVotes);
+}
+
+void ToggleFlashbangs()
+{
+  bool enabled = GetConVarBool(g_hCvar_Flashbang_Enabled);
+  SetConVarBool(g_hCvar_Flashbang_Enabled, !enabled);
+}

--- a/scripting/nt_flashbang_vote.sp
+++ b/scripting/nt_flashbang_vote.sp
@@ -27,6 +27,14 @@ public void OnPluginStart()
   g_hCvar_Flashbang_Enabled = FindConVar("sm_flashbang_enabled");
   if (g_hCvar_Flashbang_Enabled == null)
     SetFailState("NT Flashbang plugin not found.");
+
+  HookEvent("game_round_start", Event_RoundStart);
+}
+
+public Action Event_RoundStart(Handle event, const char[] name, bool dontBroadcast)
+{
+  PrintToChatAll("Turn frag grenades into flashbangs in currently: %sd", status[GetConVarBool(g_hCvar_Flashbang_Enabled)]);
+  PrintToChatAll("You can toggle this with !voteflash");
 }
 
 public void OnConfigsExecuted()

--- a/scripting/nt_flashbang_vote.sp
+++ b/scripting/nt_flashbang_vote.sp
@@ -29,6 +29,11 @@ public void OnPluginStart()
     SetFailState("NT Flashbang plugin not found.");
 }
 
+public void OnConfigsExecuted()
+{
+  AutoExecConfig(true);
+}
+
 public Action Command_VoteFlash(int client, int args)
 {
   if (!GetConVarBool(g_hCvar_Enabled))


### PR DESCRIPTION
Simplify how flash level is calculated, and give more contrast between a successful dodge and getting flashed.

Less than 75 degree dodge is now always 100% blinding, however distance from detonation reduces the blindness duration effectively. Dodging more than 75 degrees also reduces blind duration even more.

Add a complimentary voting plugin to allow toggling the plugin on/off entirely. This can also be done with more general vote plugins, using the sm_flashbang_enabled bool cvar.

